### PR TITLE
Gnome 44 and some more fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,12 @@
 
 ## Supported hardware
 
-| Model    | Supported? | Additional notes   | Confirmed by |
-| -------- | :--------: | ------------------ | ------------ |
-| UX481FLY |     ✅     |                    | @laurinneff  |
-| UX482EA  |     ✅     | without NVIDIA GPU | @jibsaramnim |
-| UX482EG  |     ❔     | with NVIDIA GPU    |              |
+| Model    | Supported? | Additional notes                           | Confirmed by |
+| -------- | :--------: | ------------------------------------------ | ------------ |
+| UX481FLY |     ✅     |                                            | @laurinneff  |
+| UX482EA  |     ✅     | without NVIDIA GPU                         | @jibsaramnim |
+| UX482EG  |     ❔     | with NVIDIA GPU                            |              |
+| UX8402   |     ✅     | without NVIDIA GPU, Ubuntu 23.04           | @allofmex    |
 
 <!-- Use ✅ for supported, ❔ for unknown/unconfirmed, ❌ for unsupported -->
 
@@ -21,3 +22,10 @@ git clone https://github.com/laurinneff/gnome-shell-extension-zenbook-duo.git
 cd gnome-shell-extension-zenbook-duo
 make install
 ```
+
+## Usage
+
+This extension will add a second brightness slider to Quicksettings (where your volume/wifi/... toggles are) to control Screenpad brightness.
+It will also add functionality to some of your Asus hardware keys like Toggle-Screenpad and MyAsus key.
+
+It will **not** link the brightness hardware keys to Screenpad display (as of now).

--- a/metadata.json
+++ b/metadata.json
@@ -3,6 +3,6 @@
   "description": "Integrate the features of the Asus ZenBook Duo into GNOME",
   "uuid": "zenbook-duo@laurinneff.ch",
   "version": "5",
-  "shell-version": ["43", "42", "41", "40"],
+  "shell-version": ["44", "43", "42", "41", "40"],
   "url": "https://github.com/laurinneff/gnome-shell-extension-zenbook-duo"
 }


### PR DESCRIPTION
Original repo seems abandoned. Thanks for keeping extension alive :-)

- Update to Gnome 44
- Screenpad-toggle key working again (was only turning off but not on before)
- Extension disabling fixed (toggling extension state was creating multiple slider)
- README improved

(note: extension needs some general cleanup)