### PR TITLE
Feature: Screenpad brightness linked to main display

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ EXTENSION_INSTALL_DIR = "$(HOME)/.local/share/gnome-shell/extensions/zenbook-duo
 FILES += extension.js
 FILES += utils.js
 FILES += keybindings.js
+FILES += featureindicator.js
 FILES += prefs.js
 FILES += prefs.ui
 FILES += metadata.json

--- a/README.md
+++ b/README.md
@@ -2,11 +2,12 @@
 
 ## Supported hardware
 
-| Model    | Supported? | Additional notes   | Confirmed by |
-| -------- | :--------: | ------------------ | ------------ |
-| UX481FLY |     ✅     |                    | @laurinneff  |
-| UX482EA  |     ✅     | without NVIDIA GPU | @jibsaramnim |
-| UX482EG  |     ❔     | with NVIDIA GPU    |              |
+| Model    | Supported? | Additional notes                           | Confirmed by |
+| -------- | :--------: | ------------------------------------------ | ------------ |
+| UX481FLY |     ✅     |                                            | @laurinneff  |
+| UX482EA  |     ✅     | without NVIDIA GPU                         | @jibsaramnim |
+| UX482EG  |     ❔     | with NVIDIA GPU                            |              |
+| UX8402   |     ✅     | without NVIDIA GPU, Ubuntu 23.04           | @allofmex    |
 
 <!-- Use ✅ for supported, ❔ for unknown/unconfirmed, ❌ for unsupported -->
 
@@ -21,3 +22,10 @@ git clone https://github.com/laurinneff/gnome-shell-extension-zenbook-duo.git
 cd gnome-shell-extension-zenbook-duo
 make install
 ```
+
+## Usage
+
+This extension will add a second brightness slider to Quicksettings (where your volume/wifi/... toggles are) to control Screenpad brightness.
+It will also add functionality to some of your Asus hardware keys like Toggle-Screenpad and MyAsus key.
+
+It will **not** link the brightness hardware keys to Screenpad display (as of now).

--- a/README.md
+++ b/README.md
@@ -29,3 +29,14 @@ This extension will add a second brightness slider to Quicksettings (where your 
 It will also add functionality to some of your Asus hardware keys like Toggle-Screenpad and MyAsus key.
 
 It will **not** link the brightness hardware keys to Screenpad display (as of now).
+
+## Debugging
+
+Test if brightness can be set to screenpad at all
+
+```
+echo 255 > '/sys/class/leds/asus::screenpad/brightness'
+```
+
+This should have set screenpad brightness to max (or less if you replace 255 by lower value). If this is not working, check the kernel module mentioned above.
+

--- a/extension.js
+++ b/extension.js
@@ -132,16 +132,17 @@ class Extension {
 
         // MyASUS key
         this._keybindingManager.add(
-            'Tools',
+            'Launch1',
             function () {
                 try {
+                    let cmd = this.settings.get_string('myasus-cmd');
+                    log('Firing cmd '+cmd);
                     // The process starts running immediately after this function is called. Any
                     // error thrown here will be a result of the process failing to start, not
                     // the success or failure of the process itself.
                     let proc = Gio.Subprocess.new(
                         // The program and command options are passed as a list of arguments
-                        ['sh', '-c', this.settings.get_string('myasus-cmd')],
-
+                        ['sh', '-c', cmd],
                         // The flags control what I/O pipes are opened and how they are directed
                         Gio.SubprocessFlags.STDOUT_PIPE | Gio.SubprocessFlags.STDERR_PIPE
                     );
@@ -202,6 +203,17 @@ class Extension {
                 this._featureIndicator.setScreenpadSliderValue(brightness / 255.0, false);
             });
         }
+
+        utils.getProductName().then((productName) => {
+            log('Zenbook-Duo extension is running on '+productName);
+            // this maybe used in future for product line specific adjustmens.
+            // E.g. the original extension used keybinding key 'Tools' for MyASUS key
+            // but for UX8402 it is 'Launch1'.
+            // It is not clear if this was changed for all zenbooks, or only on 
+            // newer versions.
+        }).catch((error) => {
+            log(error);
+        });
     }
 
     disable() {

--- a/extension.js
+++ b/extension.js
@@ -69,9 +69,9 @@ class Extension {
                         let sliderBrightness = this._featureIndicator.getScreenpadSliderBrightness();
                         let adjustedBrightness = Math.floor(sliderBrightness*255);
                         // 1 to 255, so the screenpad will always turn on
-                        this._setBrightness(Math.max(adjustedBrightness, 1));
+                        this._setBrightness(Math.max(adjustedBrightness, 1), true);
                     } else {
-                        this._setBrightness(0);
+                        this._setBrightness(0, true);
                     }
                 } catch (e) {
                     logError(e);
@@ -247,7 +247,7 @@ class Extension {
             let targetValue = Math.pow(sliderValue, (offset+1));
             //log('main '+sliderValue.toFixed(2)+ ' offset '+offset.toFixed(2)+' new '+targetValue.toFixed(2));
             let adjusted = Math.max(Math.floor(targetValue*255), 1);
-            this._setBrightness(adjusted);
+            this._setBrightness(adjusted, false);
         }
     }
 
@@ -260,7 +260,7 @@ class Extension {
             this._onMainScreenSliderChg(this._featureIndicator.getMainSliderBrightness());
         } else {
             let adjusted = Math.max(Math.floor(newValue*255), 1);
-            this._setBrightness(adjusted);
+            this._setBrightness(adjusted, true);
         }
     }
 
@@ -369,9 +369,17 @@ class Extension {
         return +ret.stdout;
     }
 
-    async _setBrightness(brightness) {
-        const ret = await utils.runScreenpadTool(true, 'set', Math.floor(brightness).toString());
-        return ret.ok;
+    /**
+     * @param brightness traget brightness (0-256)
+     * @param forced true to set value, even if screenpad is turned off (may turn on)
+     */
+    async _setBrightness(brightness, forced) {
+        const curr = await this._getBrightness();
+        if (forced || curr !== 0) {
+            const ret = await utils.runScreenpadTool(true, 'set', Math.floor(brightness).toString());
+            return ret.ok;
+        }
+        return true;
     }
 }
 

--- a/featureindicator.js
+++ b/featureindicator.js
@@ -1,0 +1,117 @@
+const {GObject} = imports.gi;
+const QuickSettings = imports.ui.quickSettings;
+// This is the live instance of the Quick Settings menu
+const QuickSettingsMenu = imports.ui.main.panel.statusArea.quickSettings;
+
+
+const FeatureSlider = GObject.registerClass(
+class FeatureSlider extends QuickSettings.QuickSlider {
+    _init(onSliderChgCb, onBtnClickCb) {
+        log('FeatureSlider._init');
+        
+        super._init({
+            iconName: 'night-light-symbolic',
+            iconReactive: true,
+            //menuEnabled: true,
+        });
+
+        // Set an accessible name for the slider
+        this.slider.accessible_name = 'Brightness';
+        
+        this._sliderChangedId = this.slider.connect('notify::value',
+            () => onSliderChgCb(this.getValue())
+        );
+
+        this._sliderIconClickedId = this.connect('icon-clicked',
+            () => onBtnClickCb()
+        );
+    }
+
+    setValue(sliderValue, notify) {
+        // sliderValue: 0.0 - 1.0
+        if (!notify) {
+            this.slider.block_signal_handler(this._sliderChangedId);
+        }
+        //log('padSliderUpdate '+this.slider.value + ', notify:'+notify);
+        this.slider.value = sliderValue;
+        if (!notify) {
+            this.slider.unblock_signal_handler(this._sliderChangedId);
+        }
+    }
+
+    getValue() {
+        // 0.0 - 1.0
+        return this.slider.value;
+    }
+
+    setLinkedStatus(isLinked) {
+        this.iconName = isLinked ? 'changes-prevent-symbolic' : 'night-light-symbolic';  // or 'night-light-disabled-symbolic'
+    }
+});
+
+var FeatureIndicator = GObject.registerClass(
+class FeatureIndicator extends QuickSettings.SystemIndicator {
+    _init(onMainSliderChgCb, onPadSliderChgCb, onSliderBtnClickCb) {
+        super._init();
+
+        // Create the slider and associate it with the indicator, being sure to
+        // destroy it along with the indicator
+        this._brightnessSlider = new FeatureSlider(onPadSliderChgCb, onSliderBtnClickCb);
+        this.quickSettingsItems.push(this._brightnessSlider);
+
+        this.connect('destroy', () => {
+            this.quickSettingsItems.forEach(item => item.destroy());
+        });
+
+        // Add the indicator to the panel
+        QuickSettingsMenu._indicators.add_child(this);
+
+        // Add the slider to the menu, this time passing `2` as the second
+        // argument to ensure the slider spans both columns of the menu
+        QuickSettingsMenu._addItems(this.quickSettingsItems, 2);
+
+        this.mainBrightnessSlider = null;
+        const mainBrightnessItem = this._findMainBrightnessItem();
+        if (mainBrightnessItem !== null) {
+            // position screenpad-slider below main brightness slider
+            QuickSettingsMenu.menu._grid.set_child_above_sibling(
+                this._brightnessSlider, mainBrightnessItem);
+    
+            this.mainBrightnessSlider = mainBrightnessItem.slider;
+            this._sliderChangedId = this.mainBrightnessSlider.connect('notify::value',
+                () => onMainSliderChgCb(this.getMainSliderBrightness())
+            );
+        } else {
+            log('Zenbook-Duo extension could not find main brightness slider. Linking brightness is not possible!');
+        }
+    }
+
+    getMainSliderBrightness() {
+        // 0.0 - 1.0
+        return this.mainBrightnessSlider !== null ?  this.mainBrightnessSlider.value : -1;
+    }
+
+    getScreenpadSliderBrightness() {
+        // 0.0 - 1.0
+        return this._brightnessSlider.getValue();
+    }
+
+    setScreenpadSliderValue(value, notify) {
+        this._brightnessSlider.setValue(value, notify);
+    }
+
+    setLinkedStatus(isLinked) {
+        this._brightnessSlider.setLinkedStatus(isLinked);
+    }
+
+    _findMainBrightnessItem() {
+        // search for gnomes default brightness slider (don't know a better was as of now)
+        for (const item of QuickSettingsMenu.menu._grid.get_children()) {
+            let name = item.constructor.name.toString();
+            if (name.includes('Brightness') && item.hasOwnProperty('slider')) {
+                return item;
+            }
+        }
+        return null;
+    }
+});

--- a/metadata.json
+++ b/metadata.json
@@ -3,6 +3,6 @@
   "description": "Integrate the features of the Asus ZenBook Duo into GNOME",
   "uuid": "zenbook-duo@laurinneff.ch",
   "version": "5",
-  "shell-version": ["43", "42", "41", "40"],
+  "shell-version": ["44", "43", "42", "41", "40"],
   "url": "https://github.com/laurinneff/gnome-shell-extension-zenbook-duo"
 }

--- a/prefs.js
+++ b/prefs.js
@@ -49,6 +49,7 @@ function buildPrefsWidget() {
         Gio.SettingsBindFlags.DEFAULT
     );
 
+    settings.set_boolean('uninstall', false); // clear dangling flags if a previous request failed
     const button_uninstall = buildable.get_object('button_uninstall');
     button_uninstall.connect('clicked', () => {
         settings.set_boolean('uninstall', true);

--- a/schemas/org.gnome.shell.extensions.zenbook-duo.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.zenbook-duo.gschema.xml
@@ -11,6 +11,10 @@
             <default>42</default>
             <summary>Default brightness for 2nd screen</summary>
         </key>
+        <key name="link-brightness" type="b">
+            <default>true</default>
+            <summary>Default setting if 2nd screen brightness is linked to main screen brightness</summary>
+        </key>
         <key name="myasus-cmd" type="s">
             <default>''</default>
             <summary>Command to run when the MyASUS key is pressed</summary>

--- a/utils.js
+++ b/utils.js
@@ -92,8 +92,20 @@ function uninstall() {
 }
 
 function runScreenpadTool(pkexecNeeded, ...params) {
+    return runShellCmd(pkexecNeeded, '/usr/local/bin/screenpad-' + TOOL_SUFFIX, ...params);
+}
+
+/**
+ * Reads device product name (like 'Zenbook UX8402ZA_UX8402ZA')
+ */
+async function getProductName() {
+    const ret = await runShellCmd(false, 'cat', '/sys/devices/virtual/dmi/id/product_name');
+    return ret.ok ? ret.stdout : null;
+}
+
+function runShellCmd(pkexecNeeded, cmd, ...params) {
     return new Promise((resolve, reject) => {
-        let args = ['/usr/local/bin/screenpad-' + TOOL_SUFFIX].concat(params);
+        let args = [cmd].concat(params);
 
         if (pkexecNeeded) {
             args.unshift(PKEXEC);

--- a/utils.js
+++ b/utils.js
@@ -38,12 +38,14 @@ function spawnProcessCheckExitCode(...argv) {
     });
 }
 
-const EXIT_SUCCESS = 0,
-    EXIT_INVALID_ARGUMENT = 1,
-    EXIT_FAILURE = 2,
-    EXIT_NEEDS_UPDATE = 3,
-    EXIT_NOT_INSTALLED = 4,
-    EXIT_NEEDS_ROOT = 5;
+var ReturnCodes = Object.freeze({
+    EXIT_SUCCESS : 0,
+    EXIT_INVALID_ARGUMENT : 1,
+    EXIT_FAILURE : 2,
+    EXIT_NEEDS_UPDATE : 3,
+    EXIT_NOT_INSTALLED : 4,
+    EXIT_NEEDS_ROOT : 5,
+});
 
 function checkInstalled() {
     return spawnProcessCheckExitCode(


### PR DESCRIPTION
(This PR expands on #1)

## Changes

- New: Screenpad slider icon can be clicked to link screenpad brightness to main displays slider.
  If linked, screenpad slider works as "offset" to main brightness (brighter or darker than main, middle position means same-as-main).
  If unlinked, screenpad slider behaves as before, independent from main display
- Fixed: "Install additional files" popup working again
- Fixed: Asus key was not working (please submit feedback if it also works on other zenbook versions than UX8402)
- Code cleanup. Quicksettings-ui code moved to own file, its non-ui code moved to Extension class. Some redundant code also removed.